### PR TITLE
Update PortMaster, Add script to fix Start+Select not quitting

### DIFF
--- a/Update-RG351P.sh
+++ b/Update-RG351P.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 clear
 
-UPDATE_DATE="11222023"
+UPDATE_DATE="12092023"
 LOG_FILE="/home/ark/update$UPDATE_DATE.log"
 UPDATE_DONE="/home/ark/.config/.update$UPDATE_DATE"
 
@@ -1195,6 +1195,40 @@ if [ ! -f "/home/ark/.config/.update11222023" ]; then
 	sudo sed -i "/title\=/c\title\=ArkOS 351P/M wuMMLe gaming" /usr/share/plymouth/themes/text.plymouth
 
 	touch "/home/ark/.config/.update11222023"
+
+fi
+
+
+if [ ! -f "/home/ark/.config/.update12092023" ]; then
+
+	printf "\n Update PortMaster, Add script in Advanced Options to fix Start+Select not quitting on RG351P+M \n" | tee -a "$LOG_FILE"
+	sudo wget --no-check-certificate https://github.com/wummle/arkos/raw/main/12092023/arkosupdate12092023.zip -O /home/ark/arkosupdate12092023.zip -a "$LOG_FILE" || rm -f /home/ark/arkosupdate12092023.zip | tee -a "$LOG_FILE"
+	if [ -f "/home/ark/arkosupdate12092023.zip" ]; then
+		sudo unzip -X -o /home/ark/arkosupdate12092023.zip -d / | tee -a "$LOG_FILE"
+		sudo rm -v /home/ark/arkosupdate12092023.zip | tee -a "$LOG_FILE"
+	else 
+		printf "\nThe update couldn't complete because the package did not download correctly.\nPlease retry the update again." | tee -a "$LOG_FILE"
+		sleep 3
+		echo $c_brightness > /sys/devices/platform/backlight/backlight/backlight/brightness
+		exit 1
+	fi
+
+
+    printf "\nMake sure permissions for the ark home directory are set to 755\n" | tee -a "$LOG_FILE"
+      sudo chown -R ark:ark /home/ark
+      sudo chmod -R 755 /home/ark
+
+    printf "\nEnsure 64bit and 32bit sdl2 is still properly linked\n" | tee -a "$LOG_FILE"
+      sudo ln -sfv /usr/lib/aarch64-linux-gnu/libSDL2.so /usr/lib/aarch64-linux-gnu/libSDL2-2.0.so.0 | tee -a "$LOG_FILE"
+      sudo ln -sfv /usr/lib/aarch64-linux-gnu/libSDL2-2.0.so.0.2800.2 /usr/lib/aarch64-linux-gnu/libSDL2.so | tee -a "$LOG_FILE"
+      sudo ln -sfv /usr/lib/arm-linux-gnueabihf/libSDL2.so /usr/lib/arm-linux-gnueabihf/libSDL2-2.0.so.0 | tee -a "$LOG_FILE"
+      sudo ln -sfv /usr/lib/arm-linux-gnueabihf/libSDL2-2.0.so.0.2800.2 /usr/lib/arm-linux-gnueabihf/libSDL2.so | tee -a "$LOG_FILE"
+
+
+	printf "\nUpdate boot text to reflect final current version of ArkOS for the 351 P/M \n" | tee -a "$LOG_FILE"
+	sudo sed -i "/title\=/c\title\=ArkOS 351P/M wuMMLe gaming" /usr/share/plymouth/themes/text.plymouth
+
+	touch "/home/ark/.config/.update12092023"
 
 fi
 


### PR DESCRIPTION
Update PortMaster to GUI version ensuring the new base assets are present and in their respective location.
Users should still launch PortMaster while connected to the internet to ensure they are on the latest PortMaster-GUI build.
Add script to Options->Advanced to fix Start+Select not quitting games and applications on RG351P and RG351M.
