### PR TITLE
Update GZDoom, add support for .doom files, fix for asoundrc

### DIFF
--- a/Update-RG351P.sh
+++ b/Update-RG351P.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 clear
 
-UPDATE_DATE="12092023"
+UPDATE_DATE="01052024"
 LOG_FILE="/home/ark/update$UPDATE_DATE.log"
 UPDATE_DONE="/home/ark/.config/.update$UPDATE_DATE"
 
@@ -267,7 +267,7 @@ fi
 
 if [ ! -f "/home/ark/.config/.update02142022" ]; then
 
-	printf "\nupdate retroarch\n" | tee -a "$LOG_FILE"
+	printf "\nUpdate Retroarch\n" | tee -a "$LOG_FILE"
 	sudo wget --no-check-certificate https://github.com/wummle/arkos/raw/main/02142022/arkosupdate02142022.zip -O /home/ark/arkosupdate02142022.zip -a "$LOG_FILE" || rm -f /home/ark/arkosupdate02142022.zip | tee -a "$LOG_FILE"
 	if [ -f "/home/ark/arkosupdate02142022.zip" ]; then
 		sudo unzip -X -o /home/ark/arkosupdate02142022.zip -d / | tee -a "$LOG_FILE"
@@ -292,7 +292,7 @@ fi
 
 if [ ! -f "/home/ark/.config/.update05142022" ]; then
 
-	printf "\nupdate extfat drivers\n" | tee -a "$LOG_FILE"
+	printf "\nUpdate extfat drivers\n" | tee -a "$LOG_FILE"
 	sudo wget --no-check-certificate https://github.com/wummle/arkos/raw/main/05142022/arkosupdate05142022.zip -O /home/ark/arkosupdate05142022.zip -a "$LOG_FILE" || rm -f /home/ark/arkosupdate05142022.zip | tee -a "$LOG_FILE"
 	if [ -f "/home/ark/arkosupdate05142022.zip" ]; then
 		sudo unzip -X -o /home/ark/arkosupdate05142022.zip -d / | tee -a "$LOG_FILE"
@@ -484,7 +484,7 @@ fi
 
 if [ ! -f "/home/ark/.config/.update12202022" ]; then
 
-	printf "\nUpdate PPSSPP to 1.14 and RetroArch to 1.14.0\n" | tee -a "$LOG_FILE"
+	printf "\nUpdate PPSSPP to 1.14, update RetroArch to 1.14.0, fix Playstation file extension typo (Credit to K-tec-UK) \n" | tee -a "$LOG_FILE"
 	sudo wget --no-check-certificate https://github.com/wummle/arkos/raw/main/12202022/arkosupdate12202022.zip -O /home/ark/arkosupdate12202022.zip -a "$LOG_FILE" || rm -f /home/ark/arkosupdate12202022.zip | tee -a "$LOG_FILE"
 	if [ -f "/home/ark/arkosupdate12202022.zip" ]; then
 		sudo unzip -X -o /home/ark/arkosupdate12202022.zip -d / | tee -a "$LOG_FILE"
@@ -1233,14 +1233,62 @@ if [ ! -f "/home/ark/.config/.update12092023" ]; then
 fi
 
 
+if [ ! -f "/home/ark/.config/.update01052024" ]; then
+
+	printf "\n Update GZDoom and add support for .doom files, Add fix for asoundrc (add /dev/asound.conf), Add script in Advanced Options to repair asoundrc \n" | tee -a "$LOG_FILE"
+	sudo wget --no-check-certificate https://github.com/wummle/arkos/raw/main/01052024/arkosupdate01052024.zip -O /home/ark/arkosupdate01052024.zip -a "$LOG_FILE" || rm -f /home/ark/arkosupdate01052024.zip | tee -a "$LOG_FILE"
+	if [ -f "/home/ark/arkosupdate01052024.zip" ]; then
+		sudo unzip -X -o /home/ark/arkosupdate01052024.zip -d / | tee -a "$LOG_FILE"
+		sudo rm -v /home/ark/arkosupdate01052024.zip | tee -a "$LOG_FILE"
+	else 
+		printf "\nThe update couldn't complete because the package did not download correctly.\nPlease retry the update again." | tee -a "$LOG_FILE"
+		sleep 3
+		echo $c_brightness > /sys/devices/platform/backlight/backlight/backlight/brightness
+		exit 1
+	fi
+
+      sudo chown -R ark:ark /opt/ 
+
+      sudo chmod 777 /usr/local/bin/doom.sh
+      sudo chmod 755 /usr/lib/aarch64-linux-gnu/libzmusic.so.1
+
+      sudo rm -f /home/ark/.config/gzdoom/gzdoom.ini.351mp
+      sudo rm -f /home/ark/.config/gzdoom/gzdoom.ini.351v
+      sudo rm -f /home/ark/.config/gzdoom/gzdoom.ini.chi
+
+      sudo chmod 755 /opt/lzdoom/*
+      sudo chmod 777 -R /home/ark/.config/lzdoom/lzdoom.ini
+
+      sudo chmod 755 /opt/gzdoom/*
+      sudo chmod 777 -R /home/ark/.config/gzdoom/gzdoom.ini
+
+    printf "\nMake sure permissions for the ark home directory are set to 755\n" | tee -a "$LOG_FILE"
+      sudo chown -R ark:ark /home/ark
+      sudo chmod -R 755 /home/ark
+
+    printf "\nEnsure 64bit and 32bit sdl2 is still properly linked\n" | tee -a "$LOG_FILE"
+      sudo ln -sfv /usr/lib/aarch64-linux-gnu/libSDL2-2.0.so.0.2800.2 /usr/lib/aarch64-linux-gnu/libSDL2.so | tee -a "$LOG_FILE"
+      sudo ln -sfv /usr/lib/aarch64-linux-gnu/libSDL2-2.0.so.0.2800.2 /usr/lib/aarch64-linux-gnu/libSDL2-2.0.so.0 | tee -a "$LOG_FILE"
+      sudo ln -sfv /usr/lib/arm-linux-gnueabihf/libSDL2-2.0.so.0.2800.2 /usr/lib/arm-linux-gnueabihf/libSDL2.so | tee -a "$LOG_FILE"
+      sudo ln -sfv /usr/lib/arm-linux-gnueabihf/libSDL2-2.0.so.0.2800.2 /usr/lib/arm-linux-gnueabihf/libSDL2-2.0.so.0 | tee -a "$LOG_FILE"
+
+
+	printf "\nUpdate boot text to reflect final current version of ArkOS for the 351 P/M \n" | tee -a "$LOG_FILE"
+	sudo sed -i "/title\=/c\title\=ArkOS 351P/M wuMMLe gaming" /usr/share/plymouth/themes/text.plymouth
+
+	touch "/home/ark/.config/.update01052024"
+
+fi
+
+
 if [ ! -f "$UPDATE_DONE-1" ]; then
 
 
 	printf "\nEnsure 64bit and 32bit sdl2 is still properly linked\n" | tee -a "$LOG_FILE"
-      sudo ln -sfv /usr/lib/aarch64-linux-gnu/libSDL2.so /usr/lib/aarch64-linux-gnu/libSDL2-2.0.so.0 | tee -a "$LOG_FILE"
       sudo ln -sfv /usr/lib/aarch64-linux-gnu/libSDL2-2.0.so.0.2800.2 /usr/lib/aarch64-linux-gnu/libSDL2.so | tee -a "$LOG_FILE"
-      sudo ln -sfv /usr/lib/arm-linux-gnueabihf/libSDL2.so /usr/lib/arm-linux-gnueabihf/libSDL2-2.0.so.0 | tee -a "$LOG_FILE"
+      sudo ln -sfv /usr/lib/aarch64-linux-gnu/libSDL2-2.0.so.0.2800.2 /usr/lib/aarch64-linux-gnu/libSDL2-2.0.so.0 | tee -a "$LOG_FILE"
       sudo ln -sfv /usr/lib/arm-linux-gnueabihf/libSDL2-2.0.so.0.2800.2 /usr/lib/arm-linux-gnueabihf/libSDL2.so | tee -a "$LOG_FILE"
+      sudo ln -sfv /usr/lib/arm-linux-gnueabihf/libSDL2-2.0.so.0.2800.2 /usr/lib/arm-linux-gnueabihf/libSDL2-2.0.so.0 | tee -a "$LOG_FILE"
 
 	printf "\nUpdate boot text to reflect final current version of ArkOS for the 351 P/M \n" | tee -a "$LOG_FILE"
 	sudo sed -i "/title\=/c\title\=ArkOS 351P/M wuMMLe ($UPDATE_DATE)" /usr/share/plymouth/themes/text.plymouth


### PR DESCRIPTION
Update GZDoom to v4.12pre
Add support for .doom files in es_systems.cfg
Add fix for asoundrc (add /dev/asound.conf)
Additionally add script to repair asound in 'Options -> Tools -> Advanced' if sound issue reoccurs
Also rightfully credit K-tec-UK for the earlier fix for finding the Playstation file extension typo in es_systems.cfg