### PR TITLE
Add AppleWin for Linux Apple II emulator (with help from christian_haitian)

### DIFF
--- a/Update-RG351P.sh
+++ b/Update-RG351P.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 clear
 
-UPDATE_DATE="03232024"
+UPDATE_DATE="03282024"
 LOG_FILE="/home/ark/update$UPDATE_DATE.log"
 UPDATE_DONE="/home/ark/.config/.update$UPDATE_DATE"
 
@@ -1505,6 +1505,43 @@ if [ ! -f "/home/ark/.config/.update03232024" ]; then
 	#sudo sed -i "/title\=/c\title\=ArkOS 351P/M wuMMLe gaming & Slayer366" /usr/share/plymouth/themes/text.plymouth
 
 	touch "/home/ark/.config/.update03232024"
+
+fi
+
+
+if [ ! -f "/home/ark/.config/.update03282024" ]; then
+
+	printf "\n Add AppleWin for Linux Apple II emulator (with help from christian_haitian) \n" | tee -a "$LOG_FILE"
+	sudo wget --no-check-certificate https://github.com/wummle/arkos/raw/main/03282024/arkosupdate03282024.zip -O /home/ark/arkosupdate03282024.zip -a "$LOG_FILE" || rm -f /home/ark/arkosupdate03282024.zip | tee -a "$LOG_FILE"
+	if [ -f "/home/ark/arkosupdate03282024.zip" ]; then
+		sudo unzip -X -o /home/ark/arkosupdate03282024.zip -d / | tee -a "$LOG_FILE"
+		sudo rm -v /home/ark/arkosupdate03282024.zip | tee -a "$LOG_FILE"
+	else
+		printf "\nThe update couldn't complete because the package did not download correctly.\nPlease retry the update again." | tee -a "$LOG_FILE"
+		sleep 3
+		echo $c_brightness > /sys/devices/platform/backlight/backlight/backlight/brightness
+		exit 1
+	fi
+
+      sudo rm -v /home/ark/add_apple2.txt
+
+      sudo chown -R ark:ark /opt/
+
+    printf "\nMake sure permissions for the ark home directory are set to 755\n" | tee -a "$LOG_FILE"
+      sudo chown -R ark:ark /home/ark
+      sudo chmod -R 755 /home/ark
+
+    printf "\nEnsure 64bit and 32bit sdl2 is still properly linked\n" | tee -a "$LOG_FILE"
+      sudo ln -sfv /usr/lib/aarch64-linux-gnu/libSDL2-2.0.so.0.2800.2 /usr/lib/aarch64-linux-gnu/libSDL2.so | tee -a "$LOG_FILE"
+      sudo ln -sfv /usr/lib/aarch64-linux-gnu/libSDL2-2.0.so.0.2800.2 /usr/lib/aarch64-linux-gnu/libSDL2-2.0.so.0 | tee -a "$LOG_FILE"
+      sudo ln -sfv /usr/lib/arm-linux-gnueabihf/libSDL2-2.0.so.0.2800.2 /usr/lib/arm-linux-gnueabihf/libSDL2.so | tee -a "$LOG_FILE"
+      sudo ln -sfv /usr/lib/arm-linux-gnueabihf/libSDL2-2.0.so.0.2800.2 /usr/lib/arm-linux-gnueabihf/libSDL2-2.0.so.0 | tee -a "$LOG_FILE"
+
+
+	printf "\nUpdate boot text to reflect final current version of ArkOS for the 351 P/M \n" | tee -a "$LOG_FILE"
+	#sudo sed -i "/title\=/c\title\=ArkOS 351P/M wuMMLe gaming & Slayer366" /usr/share/plymouth/themes/text.plymouth
+
+	touch "/home/ark/.config/.update03282024"
 
 fi
 


### PR DESCRIPTION
Add AppleWin for Linux Apple II emulator (with help from christian_haitian)

NOTE: The applewin_libretro core is also included, but relies on the original folder structure with its assets in an absolute path that is hardcoded into the binary and also runs very, very poorly.  I had edited the core binary executable to point to the folder where the standalone applewin emulator resides which is what allowed the retroarch core to function.  This core is indeed still a WIP and so I have removed it from the core selection menu in Emulation Station.  It is merely included in the same directory as the standalone as a placeholder until devs have made improvements with performance and preferably embedding the external assets into the libretro core.