### PR TITLE
Install and update Python and Python utils & htop (already in July 5th image), and install dos2unix

### DIFF
--- a/Update-RG351P.sh
+++ b/Update-RG351P.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 clear
 
-UPDATE_DATE="07052024"
+UPDATE_DATE="09082024"
 LOG_FILE="/home/ark/update$UPDATE_DATE.log"
 UPDATE_DONE="/home/ark/.config/.update$UPDATE_DATE"
 
@@ -1740,6 +1740,57 @@ if [ ! -f "/home/ark/.config/.update07052024" ]; then
 	#sudo sed -i "/title\=/c\title\=ArkOS 351P/M wuMMLe gaming & Slayer366" /usr/share/plymouth/themes/text.plymouth
 
 	touch "/home/ark/.config/.update07052024"
+
+fi
+
+
+if [ ! -f "/home/ark/.config/.update09082024" ]; then
+
+	printf "\nInstall and Update Python and Python utilities (already present in July 5th image), Install dos2unix \n" | tee -a "$LOG_FILE"
+	#sudo wget --no-check-certificate https://github.com/wummle/arkos/raw/main/09082024/arkosupdate09082024.zip -O /home/ark/arkosupdate09082024.zip -a "$LOG_FILE" || rm -f /home/ark/arkosupdate09082024.zip | tee -a "$LOG_FILE"
+	#if [ -f "/home/ark/arkosupdate09082024.zip" ]; then
+	#	sudo unzip -X -o /home/ark/arkosupdate09082024.zip -d / | tee -a "$LOG_FILE"
+	#	sudo rm -v /home/ark/arkosupdate09082024.zip | tee -a "$LOG_FILE"
+	#else
+	#	printf "\nThe update couldn't complete because the package did not download correctly.\nPlease retry the update again." | tee -a "$LOG_FILE"
+	#	sleep 3
+	#	echo $c_brightness > /sys/devices/platform/backlight/backlight/backlight/brightness
+	#	exit 1
+	#fi
+
+      sudo chown -R ark:ark /opt/
+
+    printf "\nMake sure permissions for the ark home directory are set to 755\n" | tee -a "$LOG_FILE"
+      sudo chown -R ark:ark /home/ark
+      sudo chmod -R 755 /home/ark
+
+      sudo chmod 777 /opt/inttools/gptokeyb
+      sudo chmod 666 /opt/inttools/gamecontrollerdb.txt
+      sudo chmod 666 /opt/inttools/keys.gptk
+      sudo chmod 666 /opt/inttools/keys2.gptk
+
+      sudo apt update
+      sleep 2
+      sudo apt install -y freeglut3 libarchive-zip-perl python3
+      sleep 2
+      sudo apt -y install -t eoan python3-urwid
+      sleep 2
+      sudo apt install -y libserialport0 libportmidi0 python3-pip python3-pil p7zip-full htop dos2unix
+      sleep 2
+
+    printf "\nEnsure 64bit and 32bit SDL2 are still properly linked\n" | tee -a "$LOG_FILE"
+      sudo ln -sfv /usr/lib/aarch64-linux-gnu/libSDL2.so /usr/lib/aarch64-linux-gnu/libSDL2-2.0.so.0 | tee -a "$LOG_FILE"
+      sudo ln -sfv /usr/lib/aarch64-linux-gnu/libSDL2-2.0.so.0 /usr/lib/aarch64-linux-gnu/libSDL2-2.0.so | tee -a "$LOG_FILE"
+      sudo ln -sfv /usr/lib/aarch64-linux-gnu/libSDL2-2.0.so.0.3000.3 /usr/lib/aarch64-linux-gnu/libSDL2.so | tee -a "$LOG_FILE"
+      sudo ln -sfv /usr/lib/arm-linux-gnueabihf/libSDL2.so /usr/lib/arm-linux-gnueabihf/libSDL2-2.0.so.0 | tee -a "$LOG_FILE"
+      sudo ln -sfv /usr/lib/arm-linux-gnueabihf/libSDL2-2.0.so.0 /usr/lib/arm-linux-gnueabihf/libSDL2-2.0.so | tee -a "$LOG_FILE"
+      sudo ln -sfv /usr/lib/arm-linux-gnueabihf/libSDL2-2.0.so.0.3000.3 /usr/lib/arm-linux-gnueabihf/libSDL2.so | tee -a "$LOG_FILE"
+
+
+	printf "\nUpdate boot text to reflect final current version of ArkOS for the 351 P/M \n" | tee -a "$LOG_FILE"
+	#sudo sed -i "/title\=/c\title\=ArkOS 351P/M wuMMLe gaming & Slayer366" /usr/share/plymouth/themes/text.plymouth
+
+	touch "/home/ark/.config/.update09082024"
 
 fi
 


### PR DESCRIPTION
Install and Update Python and Python utilities (already present in July 5th image)
Install htop (also present in July 5th image)
Install dos2unix

This update adds dos2unix and also gets anyone not using the July 5th image to receive the python updates